### PR TITLE
Value is not inserted after comment when other case is used

### DIFF
--- a/lib/puppet/provider/sshd_config/augeas.rb
+++ b/lib/puppet/provider/sshd_config/augeas.rb
@@ -89,7 +89,8 @@ Puppet::Type.type(:sshd_config).provide(:augeas, :parent => Puppet::Type.type(:a
           aug.set("#{path}[last()]", v)
         else
           # Prefer to create the node next to a commented out entry
-          commented = aug.match("#{base}/#comment[.=~regexp('#{label}([^a-z\.].*)?')]")
+          reg_flag = supported?(:regexpi) ? ", 'i'" : ''
+          commented = aug.match("#{base}/#comment[.=~regexp('#{label}([^a-z\.].*)?'#{reg_flag})]")
           if commented.empty?
             if aug.match("#{base}/Match").empty?
               # insert as the last line

--- a/spec/unit/puppet/provider/sshd_config/augeas_spec.rb
+++ b/spec/unit/puppet/provider/sshd_config/augeas_spec.rb
@@ -194,6 +194,31 @@ describe provider_class do
         ')
       end
 
+      it "should add it next to commented out entry with different case when on Augeas >= 1.0.0", :if => provider_class.supported?(:regexpi) do
+        apply!(Puppet::Type.type(:sshd_config).new(
+          :name     => "usedns",
+          :value    => "no",
+          :target   => target,
+          :provider => "augeas"
+        ))
+
+        augparse_filter(target, "Sshd.lns", '*[preceding-sibling::#comment[.="ShowPatchLevel no"]][label()!="Match"]', '
+          { "#comment" = "UseDNS yes" }
+          { "usedns" = "no" }
+          { "#comment" = "PidFile /var/run/sshd.pid" }
+          { "#comment" = "MaxStartups 10" }
+          { "#comment" = "PermitTunnel no" }
+          { "#comment" = "ChrootDirectory none" }
+          { "#comment" = "no default banner path" }
+          { "#comment" = "Banner none" }
+          { "#comment" = "override default of no subsystems" }
+          { "Subsystem"
+            { "sftp" = "/usr/libexec/openssh/sftp-server" }
+          }
+          { "#comment" = "Example of overriding settings on a per-user basis" }
+        ')
+      end
+
       it "should create an array entry" do
         apply!(Puppet::Type.type(:sshd_config).new(
           :name     => "AllowUsers",


### PR DESCRIPTION
When inserting `loglevel`, the entry is not inserted after the `LogLevel` comment