### PR TITLE
Updating multiple SendEnv results in wiping values

### DIFF
--- a/spec/fixtures/unit/puppet/provider/ssh_config/augeas/full
+++ b/spec/fixtures/unit/puppet/provider/ssh_config/augeas/full
@@ -48,7 +48,8 @@ Host *
 #   VisualHostKey no
 #   ProxyCommand ssh -q -W %h:%p gateway.example.com
 #   RekeyLimit 1G 1h
-    SendEnv LANG LC_*
+    SendEnv LANG
+    SendEnv LC_*
     HashKnownHosts yes
     GSSAPIAuthentication yes
     GSSAPIDelegateCredentials no

--- a/spec/unit/puppet/provider/ssh_config/augeas_spec.rb
+++ b/spec/unit/puppet/provider/ssh_config/augeas_spec.rb
@@ -135,11 +135,12 @@ describe provider_class do
         }
       }
 
-      expect(inst.size).to eq(4)
-      expect(inst[0]).to eq({:name=>"SendEnv", :ensure=>:present, :value=>["LANG", "LC_*"], :key=>"SendEnv", :host=>"*"})
-      expect(inst[1]).to eq({:name=>"HashKnownHosts", :ensure=>:present, :value=>["yes"], :key=>"HashKnownHosts", :host=>"*"})
-      expect(inst[2]).to eq({:name=>"GSSAPIAuthentication", :ensure=>:present, :value=>["yes"], :key=>"GSSAPIAuthentication", :host=>"*"})
-      expect(inst[3]).to eq({:name=>"GSSAPIDelegateCredentials", :ensure=>:present, :value=>["no"], :key=>"GSSAPIDelegateCredentials", :host=>"*"})
+      expect(inst.size).to eq(5)
+      expect(inst[0]).to eq({:name=>"SendEnv", :ensure=>:present, :value=>["LANG"], :key=>"SendEnv", :host=>"*"})
+      expect(inst[1]).to eq({:name=>"SendEnv", :ensure=>:present, :value=>["LC_*"], :key=>"SendEnv", :host=>"*"})
+      expect(inst[2]).to eq({:name=>"HashKnownHosts", :ensure=>:present, :value=>["yes"], :key=>"HashKnownHosts", :host=>"*"})
+      expect(inst[3]).to eq({:name=>"GSSAPIAuthentication", :ensure=>:present, :value=>["yes"], :key=>"GSSAPIAuthentication", :host=>"*"})
+      expect(inst[4]).to eq({:name=>"GSSAPIDelegateCredentials", :ensure=>:present, :value=>["no"], :key=>"GSSAPIDelegateCredentials", :host=>"*"})
     end
 
     describe "when creating settings" do


### PR DESCRIPTION
If an `ssh_config` file contains multiple `SendEnv` entries, like so:

```
SendEnv LANG
SendEnv LC_*
```

then updating `SendEnv` with the `ssh_config` type results in wiping all the values.

This probably applies to the `sshd_config` provider also, which uses a similar logic for entries such as `AcceptEnv`.