### PR TITLE
resource sshd_config purge removes sshd_config_subsystem settings

### DIFF
--- a/lib/puppet/provider/sshd_config/augeas.rb
+++ b/lib/puppet/provider/sshd_config/augeas.rb
@@ -119,6 +119,7 @@ Puppet::Type.type(:sshd_config).provide(:augeas, :parent => Puppet::Type.type(:a
       }.uniq.reject {|name| name.start_with?("#", "@")}
 
       settings.each do |name|
+        next if name.downcase == "subsystem"
         value = self.get_value(aug, "$target/#{name}")
         entry = {:ensure => :present, :name => name, :value => value}
         resources << new(entry) if entry[:value]
@@ -139,6 +140,7 @@ Puppet::Type.type(:sshd_config).provide(:augeas, :parent => Puppet::Type.type(:a
         }.uniq.reject {|name| name.start_with?("#", "@")}
 
         settings.each do |name|
+          next if name.downcase == "subsystem"
           value = self.get_value(aug, "#{mpath}/Settings/#{name}")
           entry = {:ensure => :present, :name => name,
                    :value => value, :condition => cond_str}

--- a/spec/unit/puppet/provider/sshd_config/augeas_spec.rb
+++ b/spec/unit/puppet/provider/sshd_config/augeas_spec.rb
@@ -136,7 +136,7 @@ describe provider_class do
         }
       }
 
-      expect(inst.size).to eq(17)
+      expect(inst.size).to eq(16)
       expect(inst[0]).to eq({:name=>"ListenAddress", :ensure=>:present, :value=>["0.0.0.0", "::"], :condition=>:absent})
       expect(inst[1]).to eq({:name=>"SyslogFacility", :ensure=>:present, :value=>["AUTHPRIV"], :condition=>:absent})
       expect(inst[2]).to eq({:name=>"AllowGroups", :ensure=>:present, :value=>["sshusers", "admins"], :condition=>:absent})
@@ -144,8 +144,8 @@ describe provider_class do
       expect(inst[4]).to eq({:name=>"PasswordAuthentication", :ensure=>:present, :value=>["yes"], :condition=>:absent})
       expect(inst[8]).to eq({:name=>"UsePAM", :ensure=>:present, :value=>["yes"], :condition=>:absent})
       expect(inst[9]).to eq({:name=>"AcceptEnv", :ensure=>:present, :value=>["LANG", "LC_CTYPE", "LC_NUMERIC", "LC_TIME", "LC_COLLATE", "LC_MONETARY", "LC_MESSAGES", "LC_PAPER", "LC_NAME", "LC_ADDRESS", "LC_TELEPHONE", "LC_MEASUREMENT", "LC_IDENTIFICATION", "LC_ALL", "LANGUAGE", "XMODIFIERS"], :condition=>:absent})
-      expect(inst[12]).to eq({:name=>"X11Forwarding", :ensure=>:present, :value=>["no"], :condition=> "User anoncvs"})
-      expect(inst[15]).to eq({:name=>"AllowAgentForwarding", :ensure=>:present, :value=>["no"], :condition=> "Host *.example.net User *"})
+      expect(inst[11]).to eq({:name=>"X11Forwarding", :ensure=>:present, :value=>["no"], :condition=> "User anoncvs"})
+      expect(inst[14]).to eq({:name=>"AllowAgentForwarding", :ensure=>:present, :value=>["no"], :condition=> "Host *.example.net User *"})
     end
 
     describe "when creating settings" do


### PR DESCRIPTION
With:


```puppet
resources{'sshd_config': purge=>true}
```

configured, it removes anything later set with sshd_config_subsystem, like:

```puppet
		sshd_config_subsystem{"sftp":
			ensure => present,
			command => "/usr/libexec/openssh/sftp-server"
		}
```

One puppet run will add the subsystem, the next will purge it, the next will add it, the next will purge it, and so on