### PR TITLE
Raise exception on missing augeasproviders_core

### DIFF
--- a/lib/puppet/provider/ssh_config/augeas.rb
+++ b/lib/puppet/provider/ssh_config/augeas.rb
@@ -1,9 +1,11 @@
+# coding: utf-8
 # Alternative Augeas-based providers for Puppet
 #
 # Copyright (c) 2012 Raphaël Pinson
 # Licensed under the Apache License, Version 2.0
 
 
+raise("Missing augeasproviders_core dependency") if Puppet::Type.type(:augeasprovider).nil?
 Puppet::Type.type(:ssh_config).provide(:augeas, :parent => Puppet::Type.type(:augeasprovider).provider(:default)) do
   desc "Uses Augeas API to update an ssh_config parameter"
 

--- a/lib/puppet/provider/sshd_config/augeas.rb
+++ b/lib/puppet/provider/sshd_config/augeas.rb
@@ -1,9 +1,10 @@
+# coding: utf-8
 # Alternative Augeas-based providers for Puppet
 #
 # Copyright (c) 2012 Raphaël Pinson
 # Licensed under the Apache License, Version 2.0
 
-
+raise("Missing augeasproviders_core dependency") if Puppet::Type.type(:augeasprovider).nil?
 Puppet::Type.type(:sshd_config).provide(:augeas, :parent => Puppet::Type.type(:augeasprovider).provider(:default)) do
   desc "Uses Augeas API to update an sshd_config parameter"
 

--- a/lib/puppet/provider/sshd_config_match/augeas.rb
+++ b/lib/puppet/provider/sshd_config_match/augeas.rb
@@ -1,9 +1,10 @@
+# coding: utf-8
 # Alternative Augeas-based providers for Puppet
 #
 # Copyright (c) 2015 Raphaël Pinson
 # Licensed under the Apache License, Version 2.0
 
-
+raise("Missing augeasproviders_core dependency") if Puppet::Type.type(:augeasprovider).nil?
 Puppet::Type.type(:sshd_config_match).provide(:augeas, :parent => Puppet::Type.type(:augeasprovider).provider(:default)) do
   desc "Uses Augeas API to update an sshd_config Match group"
 

--- a/lib/puppet/provider/sshd_config_subsystem/augeas.rb
+++ b/lib/puppet/provider/sshd_config_subsystem/augeas.rb
@@ -1,8 +1,10 @@
+# coding: utf-8
 # Alternative Augeas-based providers for Puppet
 #
 # Copyright (c) 2012 Raphaël Pinson
 # Licensed under the Apache License, Version 2.0
 
+raise("Missing augeasproviders_core dependency") if Puppet::Type.type(:augeasprovider).nil?
 Puppet::Type.type(:sshd_config_subsystem).provide(:augeas, :parent => Puppet::Type.type(:augeasprovider).provider(:default)) do
   desc "Uses Augeas API to update a Subsystem parameter in sshd_config."
 

--- a/lib/puppet/provider/sshkey/augeas.rb
+++ b/lib/puppet/provider/sshkey/augeas.rb
@@ -1,3 +1,4 @@
+# coding: utf-8
 # Alternative Augeas-based providers for Puppet
 #
 # Copyright (c) 2015 Raphaël Pinson
@@ -29,6 +30,7 @@ class Puppet::Type::Sshkey::Ensure
   end
 end
 
+raise("Missing augeasproviders_core dependency") if Puppet::Type.type(:augeasprovider).nil?
 Puppet::Type.type(:sshkey).provide(:augeas, :parent => Puppet::Type.type(:augeasprovider).provider(:default)) do
   desc "Uses Augeas API to update SSH known_hosts entries"
 


### PR DESCRIPTION
People who manage their code with r10k have to resolve dependencies by
hand (or using a generator), as such we now helpfully raise an exception
when miaugeasproviders_core is missing.