### PR TITLE
Support HostKeyAlgorithms and KexAlgorithms

### DIFF
--- a/lib/puppet/provider/ssh_config/augeas.rb
+++ b/lib/puppet/provider/ssh_config/augeas.rb
@@ -68,7 +68,7 @@ Puppet::Type.type(:ssh_config).provide(:augeas, :parent => Puppet::Type.type(:au
   end
 
   def self.set_value(aug, base, path, label, value)
-    if label =~ /Ciphers|SendEnv|MACs|GlobalKnownHostsFile/i
+    if label =~ /Ciphers|SendEnv|MACs|(HostKey|Kex)Algorithms|GlobalKnownHostsFile/i
       aug.rm("#{path}/*")
       # In case there is more than one entry, keep only the first one
       aug.rm("#{path}[position() != 1]")


### PR DESCRIPTION
sshd_config have special handling for these, along with Ciphers, MACs, etc., to allow specifying an array of values that will be concatenated in the target configuration file. ssh_config was missing this support.