### PR TITLE
sshd_config: update documentation of the value parameter

### DIFF
--- a/lib/puppet/type/sshd_config.rb
+++ b/lib/puppet/type/sshd_config.rb
@@ -27,12 +27,14 @@ given."
   newproperty(:value, :array_matching => :all) do
     desc "Value to change the setting to. The follow parameters take an array of values:
 
-- MACs;
 - AcceptEnv;
 - AllowGroups;
 - AllowUsers;
+- Ciphers;
 - DenyGroups;
-- DenyUsers.
+- DenyUsers;
+- KexAlgorithms;
+- MACs.
 
 All other parameters take a string. When passing an array to other parameters, only the first value in the array will be considered."
 


### PR DESCRIPTION
Since 2.2.0 (8d621b6c8ab580721ffb6b9d3f26635a4c6c999c), KexAlgorithms and Ciphers are considered as array values. Unfortunately, the documentation (description of the value field of sshd_config) was not updated to reflect this change...