### PR TITLE
Add support for comments in all types and providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,15 @@ Type documentation can be generated with `puppet doc -r type` or viewed on the
       value     => "yes",
     }
 
+#### manage entry with a comment
+
+    ssh_config { "ForwardAgent":
+      ensure  => present,
+      key     => "ForwardAgent",
+      value   => "no",
+      comment => "Do not forward",
+    }
+
 #### delete entry
 
     ssh_config { "HashKnownHosts":
@@ -183,6 +192,15 @@ Type documentation can be generated with `puppet doc -r type` or viewed on the
       value     => "no",
     }
 
+#### manage entry with a comment
+
+    sshd_config { "X11Forwarding":
+      ensure  => present,
+      key     => "X11Forwarding",
+      value   => "no",
+      comment => "No X11",
+    }
+
 #### delete entry
 
     sshd_config { "PermitRootLogin":
@@ -222,6 +240,13 @@ Type documentation can be generated with `puppet doc -r type` or viewed on the
       position => "after Host *.example.net",
     }
 
+#### manage entry with a comment
+
+    sshd_config_match { "Host *.example.net":
+      ensure  => present,
+      comment => "Example network",
+    }
+
 #### delete entry
 
     sshd_config_match { "User foo Host *.example.net":
@@ -242,6 +267,14 @@ Type documentation can be generated with `puppet doc -r type` or viewed on the
     sshd_config_subsystem { "sftp":
       ensure  => present,
       command => "/usr/lib/openssh/sftp-server",
+    }
+
+#### manage entry with a comment
+
+    sshd_config_subsystem { "sftp":
+      ensure  => present,
+      command => "/usr/lib/openssh/sftp-server",
+      comment => "SFTP sub",
     }
 
 #### delete entry

--- a/lib/puppet/type/ssh_config.rb
+++ b/lib/puppet/type/ssh_config.rb
@@ -9,7 +9,7 @@ Puppet::Type.newtype(:ssh_config) do
 The resource name is used for the setting name, but if the `host` is
 given, then the name can be something else and the `key` given as the name
 of the setting.
-"
+  "
 
   ensurable
 
@@ -48,6 +48,10 @@ All other parameters take a string. When passing an array to other parameters, o
     desc "Host condition for the entry."
 
     defaultto { '*' }
+  end
+
+  newproperty(:comment) do
+    desc "Text to be stored in a comment immediately above the entry.  It will be automatically prepended with the name of the variable in order for the provider to know whether it controls the comment or not."
   end
 
   autorequire(:file) do

--- a/lib/puppet/type/sshd_config.rb
+++ b/lib/puppet/type/sshd_config.rb
@@ -71,13 +71,13 @@ All other parameters take a string. When passing an array to other parameters, o
 
     def should_to_s(new_value)
       if provider.resource[:array_append]
-          # Merge the two arrays
-          is = @resource.property(:value).retrieve
-          is_arr = Array(is)
+        # Merge the two arrays
+        is = @resource.property(:value).retrieve
+        is_arr = Array(is)
 
-          super(is_arr | Array(new_value))
+        super(is_arr | Array(new_value))
       else
-          super(new_value)
+        super(new_value)
       end
     end
   end
@@ -117,7 +117,7 @@ The value can contain multiple conditions, concatenated together with
 whitespace.  This is used if the `Match` block has multiple criteria.
 
     condition => 'Host example.net User root'
-      "
+    "
 
     munge do |value|
       if value.is_a? Hash
@@ -128,6 +128,10 @@ whitespace.  This is used if the `Match` block has multiple criteria.
         Hash[*value_a]
       end
     end
+  end
+
+  newproperty(:comment) do
+    desc "Text to be stored in a comment immediately above the entry.  It will be automatically prepended with the name of the variable in order for the provider to know whether it controls the comment or not."
   end
 
   autorequire(:file) do

--- a/lib/puppet/type/sshd_config_match.rb
+++ b/lib/puppet/type/sshd_config_match.rb
@@ -84,6 +84,11 @@ Puppet::Type.newtype(:sshd_config_match) do
     end
   end
 
+  newproperty(:comment) do
+    desc "Text to be stored in a comment immediately above the entry.  It will be automatically prepended with the name of the variable in order for the provider to know whether it controls the comment or not."
+    defaultto { "created by Puppet" }
+  end
+
   autorequire(:file) do
     self[:target]
   end

--- a/lib/puppet/type/sshd_config_subsystem.rb
+++ b/lib/puppet/type/sshd_config_subsystem.rb
@@ -22,6 +22,10 @@ Puppet::Type.newtype(:sshd_config_subsystem) do
       `/etc/ssh/sshd_config`."
   end
 
+  newproperty(:comment) do
+    desc "Text to be stored in a comment immediately above the entry.  It will be automatically prepended with the name of the variable in order for the provider to know whether it controls the comment or not."
+  end
+
   autorequire(:file) do
     self[:target]
   end

--- a/spec/fixtures/unit/puppet/provider/ssh_config/augeas/full
+++ b/spec/fixtures/unit/puppet/provider/ssh_config/augeas/full
@@ -45,11 +45,13 @@ Host *
 #   Tunnel no
 #   TunnelDevice any:any
 #   PermitLocalCommand no
+#   This is a comment
 #   VisualHostKey no
 #   ProxyCommand ssh -q -W %h:%p gateway.example.com
 #   RekeyLimit 1G 1h
     SendEnv LANG LC_*
     SendEnv QUX
+    # HashKnownHosts: more secure
     HashKnownHosts yes
     GSSAPIAuthentication yes
     GSSAPIDelegateCredentials no

--- a/spec/fixtures/unit/puppet/provider/sshd_config/augeas/full
+++ b/spec/fixtures/unit/puppet/provider/sshd_config/augeas/full
@@ -29,7 +29,7 @@ ListenAddress ::
 
 # Logging
 # obsoletes QuietMode and FascistLogging
-#SyslogFacility AUTH
+#SyslogFacility: AUTHPRIV
 SyslogFacility AUTHPRIV
 #LogLevel INFO
 
@@ -83,8 +83,8 @@ GSSAPICleanupCredentials yes
 #GSSAPIStrictAcceptorCheck yes
 #GSSAPIKeyExchange no
 
-# Set this to 'yes' to enable PAM authentication, account processing, 
-# and session processing. If this is enabled, PAM authentication will 
+# Set this to 'yes' to enable PAM authentication, account processing,
+# and session processing. If this is enabled, PAM authentication will
 # be allowed through the ChallengeResponseAuthentication and
 # PasswordAuthentication.  Depending on your PAM configuration,
 # PAM authentication via ChallengeResponseAuthentication may bypass
@@ -101,6 +101,8 @@ AcceptEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT
 AcceptEnv LC_IDENTIFICATION LC_ALL LANGUAGE
 AcceptEnv XMODIFIERS
 
+#   This is a comment
+#   VisualHostKey no
 #AllowAgentForwarding yes
 #AllowTcpForwarding yes
 #GatewayPorts no

--- a/spec/fixtures/unit/puppet/provider/sshd_config_match/augeas/full
+++ b/spec/fixtures/unit/puppet/provider/sshd_config_match/augeas/full
@@ -83,8 +83,8 @@ GSSAPICleanupCredentials yes
 #GSSAPIStrictAcceptorCheck yes
 #GSSAPIKeyExchange no
 
-# Set this to 'yes' to enable PAM authentication, account processing, 
-# and session processing. If this is enabled, PAM authentication will 
+# Set this to 'yes' to enable PAM authentication, account processing,
+# and session processing. If this is enabled, PAM authentication will
 # be allowed through the ChallengeResponseAuthentication and
 # PasswordAuthentication.  Depending on your PAM configuration,
 # PAM authentication via ChallengeResponseAuthentication may bypass
@@ -101,6 +101,8 @@ AcceptEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT
 AcceptEnv LC_IDENTIFICATION LC_ALL LANGUAGE
 AcceptEnv XMODIFIERS
 
+#   This is a comment
+#   VisualHostKey no
 #AllowAgentForwarding yes
 #AllowTcpForwarding yes
 #GatewayPorts no
@@ -130,7 +132,7 @@ X11Forwarding yes
 # override default of no subsystems
 Subsystem	sftp	/usr/libexec/openssh/sftp-server
 
-# Example of overriding settings on a per-user basis
+# User anoncvs: Example of overriding settings on a per-user basis
 Match User anoncvs
 	X11Forwarding no
 	AllowTcpForwarding no

--- a/spec/fixtures/unit/puppet/provider/sshd_config_subsystem/augeas/full
+++ b/spec/fixtures/unit/puppet/provider/sshd_config_subsystem/augeas/full
@@ -102,6 +102,8 @@ AcceptEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT
 AcceptEnv LC_IDENTIFICATION LC_ALL LANGUAGE
 AcceptEnv XMODIFIERS
 
+#   This is a comment
+#   VisualHostKey no
 #AllowAgentForwarding yes
 #AllowTcpForwarding yes
 #GatewayPorts no


### PR DESCRIPTION
This PR supercedes #57 

Add support for comments in all types and providers
    
    * ssh_config
    * sshd_config
    * sshd_config_match
    * sshd_config_subsystem
    
    Co-authored-by: Jason Grammenos <jason.grammenos@mediamiser.com>
