### PR TITLE
Report key type when listing `sshkey` entries

### DIFF
--- a/lib/puppet/provider/sshkey/augeas.rb
+++ b/lib/puppet/provider/sshkey/augeas.rb
@@ -47,6 +47,10 @@ Puppet::Type.type(:sshkey).provide(:augeas, parent: Puppet::Type.type(:augeaspro
   confine feature: :augeas
   defaultfor feature: :augeas
 
+  def title
+    "#{@property_hash[:name]}@#{@property_hash[:type]}"
+  end
+
   def self.instances
     augopen do |aug, _path|
       resources = []

--- a/spec/acceptance/sshkey_spec.rb
+++ b/spec/acceptance/sshkey_spec.rb
@@ -84,6 +84,36 @@ describe 'sshkey provider' do
         end
       end
 
+      # Purging builds its list of existing keys from the provider, so it only
+      # works if each entry reports which key type it is for. Uses the default
+      # target, because that is the file purging looks at.
+      context 'purging unmanaged entries' do
+        let(:target) { '/etc/ssh/ssh_known_hosts' }
+
+        let(:manifest) do
+          <<-EOM
+            sshkey { 'keep.example.com':
+              ensure   => present,
+              type     => 'ssh-rsa',
+              key      => 'AAAAKEEPKEY',
+              provider => 'augeas',
+            }
+            resources { 'sshkey': purge => true }
+          EOM
+        end
+
+        it 'removes the unmanaged entry and keeps the declared one' do
+          on host, "printf '%s\\n' 'keep.example.com ssh-rsa AAAAKEEPKEY' 'purge.example.com ssh-rsa AAAAPURGEKEY' > #{target}"
+          apply_manifest_on(host, manifest, catch_failures: true)
+          on host, "grep '^keep.example.com ssh-rsa AAAAKEEPKEY$' #{target}"
+          on host, "grep 'purge.example.com' #{target}", acceptable_exit_codes: [1]
+        end
+
+        it 'is idempotent' do
+          apply_manifest_on(host, manifest, catch_changes: true)
+        end
+      end
+
       # This module monkeypatches the shared sshkey type, so prove the stock
       # parsed provider still works with the module loaded
       context 'entries managed with the parsed provider' do

--- a/spec/fixtures/unit/puppet/provider/sshkey/augeas/multiple_types
+++ b/spec/fixtures/unit/puppet/provider/sshkey/augeas/multiple_types
@@ -1,0 +1,3 @@
+dual.example.com ssh-rsa AAAA_RSA
+dual.example.com ssh-ed25519 AAAA_ED
+single.example.com ssh-rsa AAAA_SINGLE

--- a/spec/unit/puppet/provider/sshkey/augeas_spec.rb
+++ b/spec/unit/puppet/provider/sshkey/augeas_spec.rb
@@ -234,6 +234,23 @@ describe provider_class do
     end
   end
 
+  context 'with multiple key types for one host' do
+    let(:tmptarget) { aug_fixture('multiple_types') }
+    let(:target) { tmptarget.path }
+
+    it 'reports a distinct title and type for each entry' do
+      allow(provider_class).to receive(:target).and_return(target)
+
+      expect(provider_class.instances.map(&:title)).to eq(
+        [
+          'dual.example.com@ssh-rsa',
+          'dual.example.com@ssh-ed25519',
+          'single.example.com@ssh-rsa',
+        ],
+      )
+    end
+  end
+
   context 'with broken file' do
     let(:tmptarget) { aug_fixture('broken') }
     let(:target) { tmptarget.path }


### PR DESCRIPTION
Purging builds each candidate resource from the provider's title, so without one every entry was listed with a bare hostname and no key type. Puppet could then not match those entries against the catalog and removed keys that were declared present. The `parsed` provider gained the same method upstream in
https://github.com/puppetlabs/puppetlabs-sshkeys_core/pull/32

Fixes #130