### PR TITLE
Fix `hash_hostname` being ignored on `sshkey`

### DIFF
--- a/lib/puppet/provider/sshkey/augeas.rb
+++ b/lib/puppet/provider/sshkey/augeas.rb
@@ -5,13 +5,15 @@
 # Copyright (c) 2015-2020 Raphaël Pinson
 # Licensed under the Apache License, Version 2.0
 
+require 'puppet/parameter/boolean'
+
 # Patch sshkey type to add feature and associated param
 class Puppet::Type::Sshkey
   feature :hashed_hostnames,
           'The provider supports hashed hostnames.'
 
-  newparam(:hash_hostname, boolean: true, required_features: :hashed_hostnames) do
-    defaultto :false
+  newparam(:hash_hostname, parent: Puppet::Parameter::Boolean, boolean: true, required_features: :hashed_hostnames) do
+    defaultto false
   end
 end
 
@@ -39,6 +41,16 @@ Puppet::Type.type(:sshkey).provide(:augeas, parent: Puppet::Type.type(:augeaspro
   desc 'Uses Augeas API to update SSH known_hosts entries'
 
   has_features :hashed_hostnames
+
+  # Puppet normally generates this, but only for features declared before the
+  # type's first provider attaches, which a provider file cannot rely on.
+  def self.hashed_hostnames?
+    true
+  end
+
+  def hashed_hostnames?
+    true
+  end
 
   default_file { '/etc/ssh/ssh_known_hosts' }
 
@@ -142,7 +154,7 @@ Puppet::Type.type(:sshkey).provide(:augeas, parent: Puppet::Type.type(:augeaspro
 
   def create
     augopen! do |aug|
-      if resource[:hash_hostname] == :true
+      if resource.hash_hostname?
         [resource[:name], resource[:host_aliases]].flatten.compact.each do |h|
           create_entry(aug, h, resource[:type], resource[:key], true)
         end

--- a/spec/acceptance/sshkey_spec.rb
+++ b/spec/acceptance/sshkey_spec.rb
@@ -114,6 +114,41 @@ describe 'sshkey provider' do
         end
       end
 
+      context 'hashed entry' do
+        let(:target) { '/etc/ssh/acceptance_known_hosts_hashed' }
+
+        let(:manifest) do
+          <<-EOM
+            sshkey { 'hashed.example.com':
+              ensure        => present,
+              type          => 'ssh-rsa',
+              key           => 'AAAAHASHEDKEY',
+              hash_hostname => true,
+              target        => '#{target}',
+              provider      => 'augeas',
+            }
+          EOM
+        end
+
+        it 'creates the entry hashed' do
+          on host, "rm -f #{target}"
+          apply_manifest_on(host, manifest, catch_failures: true)
+          on host, "grep '^|1|.* ssh-rsa AAAAHASHEDKEY$' #{target}"
+          on host, "grep 'hashed.example.com' #{target}", acceptable_exit_codes: [1]
+        end
+
+        # ssh-keygen -F recomputes the HMAC from the entry's salt, so it only
+        # finds the entry if the hash really is of this hostname
+        it 'creates a hash that ssh resolves to the hostname' do
+          on host, "ssh-keygen -F hashed.example.com -f #{target}"
+          on host, "ssh-keygen -F other.example.com -f #{target}", acceptable_exit_codes: [1]
+        end
+
+        it 'is idempotent' do
+          apply_manifest_on(host, manifest, catch_changes: true)
+        end
+      end
+
       # This module monkeypatches the shared sshkey type, so prove the stock
       # parsed provider still works with the module loaded
       context 'entries managed with the parsed provider' do

--- a/spec/unit/puppet/provider/sshkey/augeas_spec.rb
+++ b/spec/unit/puppet/provider/sshkey/augeas_spec.rb
@@ -251,6 +251,40 @@ describe provider_class do
     end
   end
 
+  # If another provider for this type is loaded before this module is, Puppet
+  # builds the type's feature checks without one for hashed_hostnames, and the
+  # hash_hostname parameter gets dropped. Which provider loads first varies by
+  # installation and CI happens to get the lucky order, so remove the check to
+  # reproduce the unlucky one.
+  context 'when the type has no check for the hashed_hostnames feature' do
+    around do |example|
+      mod = Puppet::Type.type(:sshkey).const_get(:FeatureModule)
+      original = mod.instance_method(:hashed_hostnames?) if mod.method_defined?(:hashed_hostnames?)
+      mod.send(:remove_method, :hashed_hostnames?) if original
+      begin
+        example.run
+      ensure
+        mod.send(:define_method, :hashed_hostnames?, original) if original
+      end
+    end
+
+    it 'still reports the feature as supported' do
+      expect(provider_class.feature?(:hashed_hostnames)).to be true
+    end
+
+    it 'keeps the hash_hostname parameter' do
+      resource = Puppet::Type.type(:sshkey).new(
+        name: 'foo.example.com',
+        type: 'ssh-rsa',
+        key: 'DEADMEAT',
+        hash_hostname: true,
+        provider: 'augeas',
+      )
+
+      expect(resource[:hash_hostname]).to be true
+    end
+  end
+
   context 'with broken file' do
     let(:tmptarget) { aug_fixture('broken') }
     let(:target) { tmptarget.path }


### PR DESCRIPTION
Setting `hash_hostname => true` quietly wrote a plain text entry rather than a hashed one, reporting success either way. Two separate things caused it.

The parameter carries `required_features: :hashed_hostnames`, and Puppet tests that with `feature?`, which only checks whether the provider answers to `hashed_hostnames?`. Those predicates live in a module that `Puppet::Util::ProviderFeatures` builds once, when the type's first provider is attached, covering the features declared by that point. This module declares its feature on a type it does not own, so it cannot be sure of getting there first, and when it loses that race no predicate is generated, Puppet decides the provider lacks the feature, and the parameter is dropped with only a debug message. Which provider loads first depends on module layout, which is why this bites some installations and not others. Defining the predicate on the provider means `feature?` finds it however the modules load, and nothing shared is touched.

Separately, `create` compared the value against the symbol `:true`, which a manifest boolean never produces, so the plain text branch always ran. That part affected everyone.

Fixes #133