### PR TITLE
Fix `ensure => hashed` writing unusable lines for `sshkey` aliases

### DIFF
--- a/lib/puppet/provider/sshkey/augeas.rb
+++ b/lib/puppet/provider/sshkey/augeas.rb
@@ -184,7 +184,7 @@ Puppet::Type.type(:sshkey).provide(:augeas, parent: Puppet::Type.type(:augeaspro
       key = aug.get('$resource/key')
 
       # Careful: create_entry redefines $resource!
-      aliases = aug.match('$resource/alias')
+      aliases = aug.match('$resource/alias').map { |apath| aug.get(apath) }
       aug.rm('$resource/alias')
 
       aliases.each do |a|

--- a/spec/acceptance/sshkey_spec.rb
+++ b/spec/acceptance/sshkey_spec.rb
@@ -149,6 +149,39 @@ describe 'sshkey provider' do
         end
       end
 
+      context 'converting a clear entry to hashed' do
+        let(:target) { '/etc/ssh/acceptance_known_hosts_convert' }
+
+        let(:clear_manifest) do
+          <<-EOM
+            sshkey { 'convert.example.com':
+              ensure       => present,
+              type         => 'ssh-rsa',
+              key          => 'AAAACONVERTKEY',
+              host_aliases => ['convertalias.example.com'],
+              target       => '#{target}',
+              provider     => 'augeas',
+            }
+          EOM
+        end
+
+        let(:hashed_manifest) { clear_manifest.sub('present', 'hashed') }
+
+        it 'hashes the entry and its alias' do
+          on host, "rm -f #{target}"
+          apply_manifest_on(host, clear_manifest, catch_failures: true)
+          apply_manifest_on(host, hashed_manifest, catch_failures: true)
+          expect(on(host, "grep -c '^|1|.* ssh-rsa AAAACONVERTKEY$' #{target}").stdout.to_i).to eq(2)
+          on host, "grep 'convert' #{target}", acceptable_exit_codes: [1]
+          on host, "ssh-keygen -F convert.example.com -f #{target}"
+          on host, "ssh-keygen -F convertalias.example.com -f #{target}"
+        end
+
+        it 'is idempotent' do
+          apply_manifest_on(host, hashed_manifest, catch_changes: true)
+        end
+      end
+
       # This module monkeypatches the shared sshkey type, so prove the stock
       # parsed provider still works with the module loaded
       context 'entries managed with the parsed provider' do

--- a/spec/unit/puppet/provider/sshkey/augeas_spec.rb
+++ b/spec/unit/puppet/provider/sshkey/augeas_spec.rb
@@ -5,6 +5,12 @@ require 'spec_helper'
 provider_class = Puppet::Type.type(:sshkey).provider(:augeas)
 
 describe provider_class do
+  def hashed_entry_matches?(entry_value, hostname)
+    require 'base64'
+    _empty, _version, salt64, hash64 = entry_value.split('|')
+    Base64.decode64(hash64) == OpenSSL::HMAC.digest('sha1', Base64.decode64(salt64), hostname)
+  end
+
   context 'with empty file' do
     let(:tmptarget) { aug_fixture('empty') }
     let(:target) { tmptarget.path }
@@ -203,6 +209,8 @@ describe provider_class do
         aug.get('./4').should =~ %r{^\|1\|}
         aug.get('./4/type').should eq('ssh-rsa')
         aug.get('./4/key').should =~ %r{^AAAAB3NzaC1yc2}
+        expect(hashed_entry_matches?(aug.get('./2'), 'foo.example.com')).to be true
+        expect(hashed_entry_matches?(aug.get('./4'), 'foo')).to be true
       end
     end
 


### PR DESCRIPTION
A hashed line covers exactly one hostname, so converting an entry that has aliases has to write one hashed line per alias. The alias list was read with `aug.match`, which returns tree paths, so each of those lines hashed a path like `/files/etc/ssh/ssh_known_hosts/2/alias` rather than a hostname. ssh could never match them, and nor could later runs, which either failed with "type is mandatory" when the manifest left `type` unset, or quietly wrote a correct line through `host_aliases=` and left the bogus one behind for good.

Fixes #134